### PR TITLE
Bugfix: ContinueWatching view

### DIFF
--- a/MyAnimePlugin3/Constants.cs
+++ b/MyAnimePlugin3/Constants.cs
@@ -42,35 +42,37 @@ namespace MyAnimePlugin3
 		#endregion
 
 		#region Window IDs
-		public struct WindowIDs
-		{
-			/// <summary>
-			/// The main windows id.
-			/// </summary>
-			public static readonly int MAIN = 6101;
-			public static readonly int ADMIN = 6102;
-			public static readonly int FANART = 6103;
-			public static readonly int POSTERS = 6104;
-			public static readonly int CHARACTERS = 6105;
-			public static readonly int WIDEBANNERS = 6106;
-			public static readonly int RELATIONS = 6107;
-			public static readonly int CALENDAR = 6108;
-            public static readonly int ANIMEINFO = 6109;
-			public static readonly int DOWNLOADS = 6110;
-            public static readonly int COLLECTION = 6111;
-            public static readonly int BROWSER = 6112;
-            public static readonly int NEWS = 6113;
-			public static readonly int WATCHING = 6113;
-			public static readonly int RECOMMENDATIONS = 6114;
-			public static readonly int SIMILAR = 6115;
-			public static readonly int RANDOM = 6116;
-			public static readonly int PLAYLISTS = 6117;
-			public static readonly int ACTORS = 6118;
-            public static readonly int RATINGDIALOG = 6201;
-            public static readonly int RELATIONS_OLD = 610711;
 
-		}
-		#endregion
+	  public struct WindowIDs
+	  {
+	    /// <summary>
+	    /// The main windows id.
+	    /// </summary>
+	    public static readonly int MAIN = 6101;
+
+	    public static readonly int ADMIN = 6102;
+	    public static readonly int FANART = 6103;
+	    public static readonly int POSTERS = 6104;
+	    public static readonly int CHARACTERS = 6105;
+	    public static readonly int WIDEBANNERS = 6106;
+	    public static readonly int RELATIONS = 6107;
+	    public static readonly int CALENDAR = 6108;
+	    public static readonly int ANIMEINFO = 6109;
+	    public static readonly int DOWNLOADS = 6110;
+	    public static readonly int COLLECTION = 6111;
+	    public static readonly int BROWSER = 6112;
+	    public static readonly int WATCHING = 6113;
+	    public static readonly int RECOMMENDATIONS = 6114;
+	    public static readonly int SIMILAR = 6115;
+	    public static readonly int RANDOM = 6116;
+	    public static readonly int PLAYLISTS = 6117;
+	    public static readonly int ACTORS = 6118;
+	    public static readonly int RATINGDIALOG = 6201;
+	    public static readonly int RELATIONS_OLD = 610711;
+
+	  }
+
+	  #endregion
 
 		#region Control IDs
 		public struct ControlIDs

--- a/MyAnimePlugin3/MA3WindowManager.cs
+++ b/MyAnimePlugin3/MA3WindowManager.cs
@@ -71,7 +71,7 @@ namespace MyAnimePlugin3
 				case ContinueWatching:
 					GUIWindowManager.CloseCurrentWindow();
 					GUIWindowManager.ActivateWindow(Constants.WindowIDs.WATCHING, false);
-					return true;
+          return true;
 
 				case Utilities:
 					GUIWindowManager.CloseCurrentWindow();

--- a/MyAnimePlugin3/MyAnimePlugin3.csproj
+++ b/MyAnimePlugin3/MyAnimePlugin3.csproj
@@ -255,6 +255,7 @@
     <Compile Include="Windows\AnimeInfoWindow.cs" />
     <Compile Include="Windows\CalendarWindow.cs" />
     <Compile Include="Windows\CharWindow.cs" />
+    <Compile Include="Windows\ContinueWatchingWindow.cs" />
     <Compile Include="Windows\DownloadsWindow.cs" />
     <Compile Include="Windows\FanartWindow.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MyAnimePlugin3/Windows/ContinueWatchingWindow.cs
+++ b/MyAnimePlugin3/Windows/ContinueWatchingWindow.cs
@@ -344,7 +344,7 @@ namespace MyAnimePlugin3.Windows
 						case 2:
 
 							if (ep.AnimeSeries == null) return;
-							MainWindow.selectedGroupFilter = MainWindow.curGroupFilter = GroupFilterHelper.AllGroupsFilter;
+							//MainWindow.selectedGroupFilter = MainWindow.curGroupFilter = GroupFilterHelper.AllGroupsFilter;
 
 							// find the group for this series
 							AnimeGroupVM grp = JMMServerHelper.GetGroup(ep.AnimeSeries.AnimeGroupID);
@@ -353,16 +353,16 @@ namespace MyAnimePlugin3.Windows
 								BaseConfig.MyAnimeLog.Write("Group not found");
 								return;
 							}
-							MainWindow.curAnimeGroup = grp;
-							MainWindow.curAnimeGroupViewed = grp;
-							MainWindow.curAnimeSeries = ep.AnimeSeries;
+							//MainWindow.curAnimeGroup = grp;
+							//MainWindow.curAnimeGroupViewed = grp;
+							//MainWindow.curAnimeSeries = ep.AnimeSeries;
 
 							bool foundEpType = false;
 							foreach (AnimeEpisodeTypeVM anEpType in ep.AnimeSeries.EpisodeTypesToDisplay)
 							{
 								if (anEpType.EpisodeType == enEpisodeType.Episode)
 								{
-									MainWindow.curAnimeEpisodeType = anEpType;
+									//MainWindow.curAnimeEpisodeType = anEpType;
 									foundEpType = true;
 									break;
 								}
@@ -370,7 +370,7 @@ namespace MyAnimePlugin3.Windows
 
 							if (!foundEpType) return;
 
-							MainWindow.listLevel = Listlevel.Episode;
+							//MainWindow.listLevel = Listlevel.Episode;
 							GUIWindowManager.ActivateWindow(Constants.WindowIDs.MAIN, false);
 
 							break;


### PR DESCRIPTION
ContinueWatchingWindow class was no longer included in projected and had some old references from mainwindow which are no longer present which resulted in the Continue Watching view no longer working.

List of changes:

- Included ContinueWatchingWindow.cs in project and commented out functions in it which are no longer present.
- Removed duplicate ID reference from Constants.cs as NEWS seems no longer present in MA3 (no window for it)

Did a quick test on my DEV box and the view now loads with no errors in logs, however would be great if we can get some users to test it out as well :)

**Reference**: http://forum.team-mediaportal.com/threads/my-anime-3.107475/page-83#post-1195132