### PR TITLE
StreamedMP calender change and VideoHandler logging

### DIFF
--- a/MyAnimePlugin3/MyAnimePlugin3.csproj
+++ b/MyAnimePlugin3/MyAnimePlugin3.csproj
@@ -713,47 +713,47 @@
     <Content Include="Skins\Default\Anime3_WideBanners.xml" />
     <Content Include="Skins\Default\Media\hover_my anime alt.png" />
     <Content Include="Skins\Default\Media\hover_My Anime3.png" />
-    <Content Include="Skins\streamedmp\Anime3_Actors.xml" />
-    <Content Include="Skins\streamedmp\Anime3_Admin.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Actors.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_Admin.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_AnimeInfo.xml">
+    <Content Include="Skins\StreamedMP\Anime3_AnimeInfo.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Calendar.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Calendar.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Char.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Char.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Downloads.xml" />
-    <Content Include="Skins\streamedmp\Anime3_Dummy.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Downloads.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_Dummy.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Main.fanart.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Main.fanart.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Main.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Main.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Posters.xml" />
-    <Content Include="Skins\streamedmp\Anime3_QueueStatus.fanart.xml" />
-    <Content Include="Skins\streamedmp\Anime3_QueueStatus.xml" />
-    <Content Include="Skins\streamedmp\Anime3_Random.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Posters.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_QueueStatus.fanart.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_QueueStatus.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_Random.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_Recommendations.xml" />
-    <Content Include="Skins\streamedmp\Anime3_Relations.xml">
+    <Content Include="Skins\StreamedMP\Anime3_Recommendations.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_Relations.xml">
       <SubType>Designer</SubType>
     </Content>
-    <Content Include="Skins\streamedmp\Anime3_FanArt.xml" />
-    <Content Include="Skins\streamedmp\Anime3_SkinSettings.xml" />
-    <Content Include="Skins\streamedmp\Anime3_Watching.xml" />
-    <Content Include="Skins\streamedmp\Anime3_WideBanners.xml" />
-    <Content Include="Skins\streamedmp\Media\MyAnime3\anime3_focusframe.png" />
-    <Content Include="Skins\streamedmp\Media\hover_My Anime3.png" />
-    <Content Include="Skins\streamedmp\Media\MyAnime3\overlay_bar_bottom.png" />
-    <Content Include="Skins\streamedmp\Media\MyAnime3\overlay_bar_top.png" />
+    <Content Include="Skins\StreamedMP\Anime3_FanArt.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_SkinSettings.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_Watching.xml" />
+    <Content Include="Skins\StreamedMP\Anime3_WideBanners.xml" />
+    <Content Include="Skins\StreamedMP\Media\MyAnime3\anime3_focusframe.png" />
+    <Content Include="Skins\StreamedMP\Media\hover_My Anime3.png" />
+    <Content Include="Skins\StreamedMP\Media\MyAnime3\overlay_bar_bottom.png" />
+    <Content Include="Skins\StreamedMP\Media\MyAnime3\overlay_bar_top.png" />
     <Content Include="Skins\Titan\Anime3_Actors.xml" />
     <Content Include="Skins\Titan\Anime3_Admin.xml" />
     <Content Include="Skins\Titan\Anime3_AnimeInfo.xml" />

--- a/MyAnimePlugin3/Skins/StreamedMP/Anime3_Calendar.xml
+++ b/MyAnimePlugin3/Skins/StreamedMP/Anime3_Calendar.xml
@@ -268,24 +268,6 @@
     </control>
     <!--  ************** BUTTONS TOOLBAR *****************  -->
     <control>
-      <description>Middle</description>
-      <type>button</type>
-      <id>83</id>
-      <label>#Anime3.Calendar.MinusOneMonth #Anime3.Calendar.MinusOneYear</label>
-      <width>120</width>
-      <width>180</width>
-      <posX>400</posX>
-      <posX>600</posX>
-      <posY>80</posY>
-      <posY>120</posY>
-      <onleft>920</onleft>
-      <onright>84</onright>
-      <font>mediastream12c</font>
-      <align>center</align>
-      <ondown>50</ondown>
-      <onup>50</onup>
-    </control>
-    <control>
       <description>Curent Month</description>
       <type>label</type>
       <id>0</id>
@@ -303,7 +285,7 @@
       <align>center</align>
     </control>
     <control>
-      <description>Curent Month</description>
+      <description>Current Month</description>
       <type>label</type>
       <id>0</id>
       <posX>28</posX>
@@ -319,24 +301,6 @@
       <label>Nothing found for #Anime3.Calendar.CurrentMonth #Anime3.Calendar.CurrentYear</label>
       <align>center</align>
       <visible>!Control.IsVisible(1401)</visible>
-    </control>
-    <control>
-      <description>Middle</description>
-      <type>button</type>
-      <id>84</id>
-      <label>#Anime3.Calendar.PlusOneMonth #Anime3.Calendar.PlusOneYear</label>
-      <width>120</width>
-      <width>180</width>
-      <posX>750</posX>
-      <posX>1125</posX>
-      <posY>80</posY>
-      <posY>120</posY>
-      <onleft>83</onleft>
-      <onright>920</onright>
-      <font>mediastream12c</font>
-      <align>center</align>
-      <ondown>50</ondown>
-      <onup>50</onup>
     </control>
     <!--  ************** SELECTED SERIES *****************  -->
     <control>

--- a/MyAnimePlugin3/VideoHandler.cs
+++ b/MyAnimePlugin3/VideoHandler.cs
@@ -617,23 +617,32 @@ namespace MyAnimePlugin3
 		#endregion
 
         #region Helpers
-        bool PlayBackOpIsOfConcern(MediaPortal.Player.g_Player.MediaType type, string filename)
+
+      bool PlayBackOpIsOfConcern(MediaPortal.Player.g_Player.MediaType type, string filename)
+      {
+        bool IsOfConcern = curEpisode != null && type == g_Player.MediaType.Video &&
+                           (IsStreaming(curMedia) ? curEpisode.DisplayName == filename : curFileName == filename);
+        if (IsOfConcern)
         {
-			BaseConfig.MyAnimeLog.Write("PlayBackOpIsOfConcern: {0} - {1} - {2}", filename, type, curEpisode);
-            return (curEpisode != null &&
-                    type == g_Player.MediaType.Video &&
-                    (IsStreaming(curMedia) ? curEpisode.DisplayName ==  filename : curFileName == filename));
+          BaseConfig.MyAnimeLog.Write("PlayBackOpIsOfConcern: {0} - {1} - {2}", filename, type, curEpisode);
         }
 
-		bool PlayBackOpWasOfConcern(MediaPortal.Player.g_Player.MediaType type, string filename)
-		{
-			BaseConfig.MyAnimeLog.Write("PlayBackOpWasOfConcern: {0} - {1} - {2}", filename, type, prevEpisode);
-			return (prevEpisode != null &&
-					type == g_Player.MediaType.Video &&
-                    (IsStreaming(prevMedia) ? prevEpisode.DisplayName == filename : prevFileName == filename));
-		}
+        return IsOfConcern;
+      }
 
-        void PlaybackOperationEnded(bool countAsWatched, AnimeEpisodeVM ep)
+      bool PlayBackOpWasOfConcern(MediaPortal.Player.g_Player.MediaType type, string filename)
+      {
+        bool WasOfConcern = prevEpisode != null && type == g_Player.MediaType.Video &&
+                            (IsStreaming(prevMedia) ? prevEpisode.DisplayName == filename : prevFileName == filename);
+        if (WasOfConcern)
+        {
+          BaseConfig.MyAnimeLog.Write("PlayBackOpWasOfConcern: {0} - {1} - {2}", filename, type, prevEpisode);
+        }
+
+        return WasOfConcern;
+      }
+
+      void PlaybackOperationEnded(bool countAsWatched, AnimeEpisodeVM ep)
         {
 			try
 			{

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -2575,7 +2575,6 @@ private bool ShowOptionsMenu(string previousMenu)
           || (m_Facade.CurrentLayout == GUIFacadeControl.Layout.Filmstrip && m_Facade.FilmstripLayout.IsFocused)
           || (m_Facade.CurrentLayout == GUIFacadeControl.Layout.CoverFlow && m_Facade.CoverFlowLayout.IsFocused))
       {
-
         // For some reason keycode [ and ] aren't lining up to their WinForm keycode counterpart so we have this workaround first
         char keycode = (char)keycodeInput;
         string keycodeString = KeycodeToString(keycodeInput).ToLower();


### PR DESCRIPTION
- Removed calendar navigation via buttons from StreamedMP skin as window code no longer supports it.
- VideoHandler.cs now only logs playback events if relevant to plugin.