### PR TITLE
Key command handler skips fullscreen toggle key and StreamedMP skin tweak

### DIFF
--- a/MyAnimePlugin3/Skins/Titan/Anime3_Random.xml
+++ b/MyAnimePlugin3/Skins/Titan/Anime3_Random.xml
@@ -643,7 +643,7 @@
 	  <onleft>10</onleft>
 	  <onleft>901</onleft>
 	  <onright>823</onright>
-	  <onup>801</onup>
+	  <onup>804</onup>
 	  <ondown>822</ondown>
 	  <posX>60</posX>
 	  <posY>860</posY>

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -2580,8 +2580,6 @@ private bool ShowOptionsMenu(string previousMenu)
         // For some reason keycode [ and ] aren't lining up to their WinForm keycode counterpart so we have this workaround first
         char keycode = (char)keycodeInput;
         string keycodeString = KeycodeToString(keycodeInput).ToLower();
-        Log.Error("Keycode pressed: " + keycodeInput);
-        Log.Error("Keys pressed: " + keycodeString);
 
         switch (keycodeString)
         {
@@ -2591,6 +2589,12 @@ private bool ShowOptionsMenu(string previousMenu)
           case "]":
             OnSearchAction(SearchAction.ToggleMode);
             return;
+          case "x":
+            // Skip default fullscreen toggle key if video is playing
+            if (g_Player.Playing)
+              return;
+
+            break;
         }
 
         // Normal keycode matching for everything else


### PR DESCRIPTION
Skip processing default toggle full screen video key if video is playing.
Small tweak to button navigation in StreamedMP random view.