### PR TITLE
Misc improvements and fix

### DIFF
--- a/MyAnimePlugin3/Extensions.cs
+++ b/MyAnimePlugin3/Extensions.cs
@@ -24,16 +24,26 @@ namespace MyAnimePlugin3
             }
             return res;
         }
-        public static string GetPropertyName(this GUIWindow window, string which)
+
+        public static string GetPropertyName(this GUIWindow window, string which, bool isInternalMediaportal = false)
         {
-            return BaseProperties + "." + which.Replace("_", ".").Replace("ñ", "_");
+            string PropertyName = string.Format("{0}.{1}", BaseProperties, which.Replace("_", ".").Replace("ñ", "_"));
+
+            if (isInternalMediaportal)
+            {
+                PropertyName = string.Format("#{0}", which.Replace("_", ".").Replace("ñ", "_"));
+            }
+
+            return PropertyName;
         }
-        public static void SetGUIProperty(this GUIWindow window, string which, string value)
+
+        public static void SetGUIProperty(this GUIWindow window, string which, string value, bool isInternalMediaportal = false)
         {
             if (string.IsNullOrEmpty(value))
                 value = " ";
-            GUIPropertyManager.SetProperty(window.GetPropertyName(which), value);
+            GUIPropertyManager.SetProperty(window.GetPropertyName(which, isInternalMediaportal), value);
         }
+
 
         public static void ClearGUIProperty(this GUIWindow window, string which)
         {

--- a/MyAnimePlugin3/VideoHandler.cs
+++ b/MyAnimePlugin3/VideoHandler.cs
@@ -338,12 +338,12 @@ namespace MyAnimePlugin3
             SetGUIProperty(GuiProperty.Play_Current_Plot, clear ? "" : curEpisode.EpisodeOverview, true);
             SetGUIProperty(GuiProperty.Play_Current_PlotOutline, clear ? "" : curEpisode.Description, true);
             SetGUIProperty(GuiProperty.Play_Current_Rating, clear ? "" : rating, true);
-            SetGUIProperty(GuiProperty.Play_Current_TagLine, rating + " | 0", true);
-            SetGUIProperty(GuiProperty.Play_Current_IsWatched, rating + " | 1", true);
-            SetGUIProperty(GuiProperty.Play_Current_Runtime, rating + " | 2", true);
 
             // Optional labels
             /*
+            SetGUIProperty(GuiProperty.Play_Current_TagLine, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_IsWatched, string.Empty", true);
+            SetGUIProperty(GuiProperty.Play_Current_Runtime, string.Empty, true);
             SetGUIProperty(GuiProperty.Play_Current_Cast, string.Empty, true);
             SetGUIProperty(GuiProperty.Play_Current_Votes, string.Empty);
             SetGUIProperty(GuiProperty.Play_Current_PlotKeywords, string.Empty, true);

--- a/MyAnimePlugin3/VideoHandler.cs
+++ b/MyAnimePlugin3/VideoHandler.cs
@@ -44,10 +44,37 @@ using Stream = MyAnimePlugin3.JMMServerBinary.Stream;
 
 namespace MyAnimePlugin3
 {
-    public class VideoHandler
+    public class VideoHandler : GUIWindow
     {
+        #region GUI Properties
+
+        public enum GuiProperty
+        {
+            Play_Current_Cast,
+            Play_Current_Collections,
+            Play_Current_Credits,
+            Play_Current_DVDLabel,
+            Play_Current_Director,
+            Play_Current_File,
+            Play_Current_Genre,
+            Play_Current_IMDBNumber,
+            Play_Current_IsWatched,
+            Play_Current_MPAARating,
+            Play_Current_PlotKeywords,
+            Play_Current_Runtime,
+            Play_Current_Studios,
+            Play_Current_TagLine,
+            Play_Current_Votes,
+            Play_Current_Plot,
+            Play_Current_PlotOutline,
+            Play_Current_Rating,
+            Play_Current_Title,
+            Play_Current_Year
+        }
+        #endregion
+
         #region Vars
-		public AnimeEpisodeVM curEpisode = null;
+        public AnimeEpisodeVM curEpisode = null;
 		public AnimeEpisodeVM prevEpisode = null;
         private string curFileName = "";
 		private string prevFileName = "";
@@ -104,10 +131,22 @@ namespace MyAnimePlugin3
         }
 
         #region Public Methods
+        public void SetGUIProperty(GuiProperty which, string value, bool isInternalMediaportal = false) { this.SetGUIProperty(which.ToString(), value, isInternalMediaportal); }
+        public void ClearGUIProperty(GuiProperty which) { this.ClearGUIProperty(which.ToString()); }
+        public string GetPropertyName(GuiProperty which) { return this.GetPropertyName(which.ToString()); }
 
+        private static string StaticGetPropertyName(string which)
+        {
+            return Extensions.BaseProperties + "." + which.Replace("_", ".").Replace("ñ", "_");
+        }
+        public static void StaticSetGUIProperty(GuiProperty which, string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                value = " ";
+            GUIPropertyManager.SetProperty(StaticGetPropertyName(which.ToString()), value);
+        }
 
-
-		public bool ResumeOrPlay(VideoLocalVM fileToPlay)
+        public bool ResumeOrPlay(VideoLocalVM fileToPlay)
 		{
 			try
 			{
@@ -291,9 +330,38 @@ namespace MyAnimePlugin3
 			if (curEpisode == null) return;
 
 			string displayName = curEpisode.EpisodeNumberAndName;
+            string rating = Utils.FormatAniDBRating(Convert.ToDouble(curEpisode.AniDB_Rating)) + " (" + curEpisode.AniDB_Votes + " " + Translation.Votes + ")";
+            string formattedEpNameAndAirdate = $"{displayName} [{curEpisode.AirDateAsString}]";
 
-			MediaPortal.GUI.Library.GUIPropertyManager.SetProperty("#Play.Current.Title", clear ? "" : displayName);
-			MediaPortal.GUI.Library.GUIPropertyManager.SetProperty("#Play.Current.Plot", clear ? "" : curEpisode.Description);
+            SetGUIProperty(GuiProperty.Play_Current_Title, clear ? "" : curEpisode.AnimeSeries.SeriesName, true);
+            SetGUIProperty(GuiProperty.Play_Current_Year, clear ? "" : formattedEpNameAndAirdate, true);
+            SetGUIProperty(GuiProperty.Play_Current_Plot, clear ? "" : curEpisode.EpisodeOverview, true);
+            SetGUIProperty(GuiProperty.Play_Current_PlotOutline, clear ? "" : curEpisode.Description, true);
+            SetGUIProperty(GuiProperty.Play_Current_Rating, clear ? "" : rating, true);
+            SetGUIProperty(GuiProperty.Play_Current_TagLine, rating + " | 0", true);
+            SetGUIProperty(GuiProperty.Play_Current_IsWatched, rating + " | 1", true);
+            SetGUIProperty(GuiProperty.Play_Current_Runtime, rating + " | 2", true);
+
+            // Optional labels
+            /*
+            SetGUIProperty(GuiProperty.Play_Current_Cast, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Votes, string.Empty);
+            SetGUIProperty(GuiProperty.Play_Current_PlotKeywords, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Cast, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_File, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_DVDLabel, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_IMDBNumber, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Runtime, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_MPAARating, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_IsWatched, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_TagLine, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Director, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Genre, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Credits, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Studios, string.Empty, true);
+            SetGUIProperty(GuiProperty.Play_Current_Collections, string.Empty, true);
+            */
+
             try
             {
                 string imgNameSeries = curEpisode.AnimeSeries.PosterPath;

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -2580,6 +2580,10 @@ private bool ShowOptionsMenu(string previousMenu)
 
       private void KeyCommandHandler(int keycodeInput)
       {
+            // Skip key command processing if video window is fullscreen
+            if (g_Player.FullScreen)
+                return;
+
           //when the list is selected, search the input
           if ((m_Facade.CurrentLayout == GUIFacadeControl.Layout.List && m_Facade.ListLayout.IsFocused)
               || (m_Facade.CurrentLayout == GUIFacadeControl.Layout.LargeIcons && m_Facade.ThumbnailLayout.IsFocused)
@@ -3563,39 +3567,49 @@ private bool ShowOptionsMenu(string previousMenu)
       }
       else if (settings.LoadLocalThumbnails)
       {
-        string localThumbnail = LoadLocalThumbnail(ep.AnimeEpisodeID);
+          ClearGUIProperty(GuiProperty.Episode_Image);
+          string localThumbnail = LoadLocalThumbnail(ep.AnimeEpisodeID);
 
-        // Try to find local thumbnail
-        if (string.IsNullOrEmpty(localThumbnail))
-        {
-          // Fallback to default thumbnail if none found
-          SetGUIProperty(GuiProperty.Episode_Image, ep.EpisodeImageLocation);
-          fanartTexture.Filename = GUIGraphicsContext.Skin + @"\Media\hover_my anime3.jpg";
-        }
-        else
-        {
-          // Set thumbnail to local and replace fanart image with it as well
-          SetGUIProperty(GuiProperty.Episode_Image, localThumbnail);
+          // Try to find local thumbnail
+          if (string.IsNullOrEmpty(localThumbnail))
+          {
+              // Fallback to default thumbnail if none found
+              SetGUIProperty(GuiProperty.Episode_Image, ep.EpisodeImageLocation);
+              fanartTexture.Filename = GUIGraphicsContext.Skin + @"\Media\hover_my anime3.jpg";
+          }
+          else
+          {
+              // Set thumbnail to local and replace fanart image with it as well
+              SetGUIProperty(GuiProperty.Episode_Image, localThumbnail);
 
-          fanartTexture.Filename = localThumbnail;
+              fanartTexture.Filename = localThumbnail;
 
-          if (this.dummyIsFanartLoaded != null)
-            this.dummyIsFanartLoaded.Visible = true;
-        }
+              if (this.dummyIsFanartLoaded != null)
+                  this.dummyIsFanartLoaded.Visible = true;
+          }
       }
       else
       {
-        ClearGUIProperty(GuiProperty.Episode_Image);
+          ClearGUIProperty(GuiProperty.Episode_Image);
       }
 
-      if (!settings.HidePlot)
+        if (!settings.HidePlot)
         SetGUIProperty(GuiProperty.Episode_Description, ep.EpisodeOverview);
       else
       {
-        if (ep.EpisodeOverview.Trim().Length > 0 && ep.IsWatched == 0)
-          SetGUIProperty(GuiProperty.Episode_Description, "*** " + Translation.HiddenToPreventSpoiles + " ***");
-        else
-          SetGUIProperty(GuiProperty.Episode_Description, ep.EpisodeOverview);
+          if (ep.EpisodeOverview.Trim().Length > 0 && ep.IsWatched == 0)
+          {
+              SetGUIProperty(GuiProperty.Episode_Description, "*** " + Translation.HiddenToPreventSpoiles + " ***");
+          }
+          else if (!string.IsNullOrEmpty(ep.EpisodeOverview))
+          {
+
+              SetGUIProperty(GuiProperty.Episode_Description, ep.EpisodeOverview);
+          }
+          else
+          {
+              ClearGUIProperty(GuiProperty.Episode_Description);
+          }
       }
 
       SetGUIProperty(GuiProperty.Episode_EpisodeName, ep.EpisodeName);


### PR DESCRIPTION
Extensions.cs can now also handle internal GUI properties (those without plugin prefix).

Added GUI property functions to VideoHandler.cs as well and updated play info labels which no include title and airdate, depending on skin it will also display a formatted AniDB rating.

Will skip key command processing if video window is full screen, extra precaution as by default when video is fullsceen it should already not handle keys.

Possible fix for episode description and image not resetting in all cases:

http://forum.team-mediaportal.com/threads/my-anime-3.107475/page-87#post-1195519