### PR TITLE
Thumbnail custom path change and fix for certain view cases

### DIFF
--- a/MyAnimePlugin3/Utils.cs
+++ b/MyAnimePlugin3/Utils.cs
@@ -856,7 +856,13 @@ namespace MyAnimePlugin3
 			AnimePluginSettings settings = new AnimePluginSettings();
 			string filePath = Path.Combine(settings.ThumbsFolder, "Anime3");
 
-			if (!Directory.Exists(filePath))
+            // If user has custom thumbs folder do not add additional folder to path to allows for shared server thumb path
+            if (settings.HasCustomThumbsFolder)
+            {
+                filePath = settings.ThumbsFolder;
+            }
+
+            if (!Directory.Exists(filePath))
 				Directory.CreateDirectory(filePath);
 
 			return filePath;

--- a/MyAnimePlugin3/Windows/MainWindow.cs
+++ b/MyAnimePlugin3/Windows/MainWindow.cs
@@ -3611,6 +3611,9 @@ private bool ShowOptionsMenu(string previousMenu)
               ClearGUIProperty(GuiProperty.Episode_Description);
           }
       }
+     // Make sure to set title again, needed for direct series list navigations (continue watching / something random)
+     if (GetPropertyName(GuiProperty.Title) != ep.AnimeSeries.SeriesName)
+         SetGUIProperty(GuiProperty.Title, ep.AnimeSeries.SeriesName);
 
       SetGUIProperty(GuiProperty.Episode_EpisodeName, ep.EpisodeName);
       SetGUIProperty(GuiProperty.Episode_EpisodeDisplayName, ep.DisplayName);


### PR DESCRIPTION
If user has setup custom thumbnail / image path in configuration it no longer adds "Anime3" to path to allow for shared storage with JMM server.

Always set title label in episode view, needed when navigating directly to this view from for instance Continue Watching or Something Random.